### PR TITLE
feat: add mongo session store

### DIFF
--- a/Back-end/server.js
+++ b/Back-end/server.js
@@ -3,6 +3,7 @@ import bodyParser from "body-parser";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import session from "express-session";
+import MongoStore from "connect-mongo";
 import ejs from "ejs";
 import methodOverride from "method-override";
 import "dotenv/config";
@@ -35,12 +36,18 @@ app.use(express.static(join(__dirname, "../public")));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(methodOverride("_method"));
 
+// Session store
+const store = MongoStore.create({
+  mongoUrl: process.env.SESSION_DB_URI || process.env.MONGO_URI,
+});
+
 // Session middleware
 app.use(
   session({
     secret: process.env.SESSION_SECRET, // Should be in environment variables
     resave: false,
     saveUninitialized: false,
+    store,
     cookie: {
       secure: false, // Set to true in production with HTTPS
       maxAge: 30 * 60 * 1000, // half hour

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "express-session": "^1.18.2",
+    "connect-mongo": "^5.1.0",
     "method-override": "^3.0.0",
     "mongodb": "^6.1.7",
     "mongoose": "^8.16.5",


### PR DESCRIPTION
## Summary
- persist sessions using MongoDB backed store via connect-mongo
- configure store via environment variables and pass to express-session

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892be35d21483329acbb815b3b8b9b5